### PR TITLE
Fix V8 deoptimization due to arguments handling in _read

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -28,7 +28,7 @@ Object.defineProperty(Reader.prototype, 'context', {
 
 function _read(fn, path) {
     var r, i, _path = [];
-
+    var args, len = arguments.length;
     if (typeof path === 'string') {
         _path = [path];
     } else if (Array.isArray(path)) {
@@ -39,7 +39,16 @@ function _read(fn, path) {
         this.path.push(_path[i]);
     }
 
-    r = fn.apply(this, Array.prototype.slice.call(arguments, 2));
+    if (len > 2) {
+        args = new Array(len - 2);
+        for (i = 0; i < args.length; ++i) {
+            args[i] = arguments[i + 2];
+        }
+    } else {
+        args = [];
+    }
+
+    r = fn.apply(this, args);
 
     if (r !== undefined) {
         if (this.path.length) {


### PR DESCRIPTION
Same optimization as was done for the `_write` method. 
I am using this library through `no-kafka` so if accepted it would be great if the kafka library was updated with the new version.

cc @gerad, @dirkkessler